### PR TITLE
大佬，发现您的项目引入了com.alibaba:fastjson@1.2.41组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>me.zbl</groupId>
     <artifactId>fsblog</artifactId>
@@ -302,7 +300,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.41</version>
+            <version>1.2.69</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Fastjson 1.2.25-1.2.47版本远程代码执行漏洞
缺陷组件：com.alibaba:fastjson@1.2.41
漏洞编号：
漏洞描述：Fastjson 是Java语言实现的快速JSON解析和生成器，在1.2.25-1.2.47版本中攻击者可通过精心构造的JSON请求，绕过此前修复机制，远程执行任意代码。
漏洞原因：
攻击者可通过白名单类java.lang.Class绕过checkAutotype方法，利用fastjson的cache机制引入恶意类，并调用连接远程rmi主机，通过其中的恶意类执行代码。
影响范围：[1.2.25, 1.2.48)
最小修复版本：1.2.69
缺陷组件引入路径：me.zbl:fsblog@1.0-Release->com.alibaba:fastjson@1.2.41
```
另外我运行这个项目时，IDE的安全插件提示还有87个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p4c582